### PR TITLE
cache node_modules on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: node_js
 # node_js: travis will use the version specified in .nvmrc
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
save time in ci ([docs](https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies)).

todo: consider using yarn

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO